### PR TITLE
Update to use xcbuild definition

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,9 +7,10 @@ let package = Package(
         .executable(name: "selfish", targets: ["selfish"])
     ],
     dependencies: [
-        .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.21.1")
+        .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.21.1"),
+        .package(url: "https://github.com/jpsim/Yams.git", from: "1.0.0")
     ],
     targets: [
-        .target(name: "selfish", dependencies: ["SourceKittenFramework"])
+        .target(name: "selfish", dependencies: ["SourceKittenFramework", "Yams"])
     ]
 )

--- a/Sources/selfish/main.swift
+++ b/Sources/selfish/main.swift
@@ -151,7 +151,6 @@ private func parseXCBuildDefinition(_ logString: String) throws -> [String: [Str
     return fileToArgs
 }
 
-
 private let kindsToFind = Set([
     "source.lang.swift.ref.function.method.instance",
     "source.lang.swift.ref.var.instance"

--- a/Sources/selfish/main.swift
+++ b/Sources/selfish/main.swift
@@ -116,7 +116,8 @@ private enum ParsingError: LocalizedError {
 }
 
 private func stripXCBuildExec(from arguments: [String]) throws -> [String] {
-    if let index = arguments.index(of: "--") {
+    if let dashIndex = arguments.index(of: "--") {
+        let index = arguments.index(after: dashIndex)
         return Array(arguments[index...])
     }
 

--- a/Sources/selfish/main.swift
+++ b/Sources/selfish/main.swift
@@ -18,10 +18,10 @@ final class CompilableFile {
     let file: String
     let compilerArguments: [String]
 
-    init?(file: String, args: [String]?) {
+    init?(file: String, arguments: [String]?) {
         self.file = file
-        if let args = args {
-            self.compilerArguments = args
+        if let arguments = arguments {
+            self.compilerArguments = arguments
         } else {
             return nil
         }
@@ -268,7 +268,7 @@ DispatchQueue.concurrentPerform(iterations: files.count) { index in
     let path = files[index]
     let arguments = buildDefinition[path]
 
-    guard let compilableFile = CompilableFile(file: path, args: arguments) else {
+    guard let compilableFile = CompilableFile(file: path, arguments: arguments) else {
         print("Couldn't find compiler arguments for file. Skipping: \(path)")
         return
     }

--- a/Sources/selfish/main.swift
+++ b/Sources/selfish/main.swift
@@ -262,7 +262,6 @@ guard let data = FileManager.default.contents(atPath: logPath),
 }
 
 let buildDefinition = try parseXCBuildDefinition(logContents)
-
 let files = FileManager.default.filesToLint(inPath: "")
 DispatchQueue.concurrentPerform(iterations: files.count) { index in
     let path = files[index]


### PR DESCRIPTION
This changes the log parsing code of selfish to use the xcbuild definition file instead. You can generate this file by running:

```
xcodebuild -dry-run
```

When your project is setup to use the new build system. This command will fail with the error:

```
error: -dry-run is not yet supported in the new build system
```

But the definition will be generated before it fails. You can find the build definition in:

```
$(DERIVED_DATA_DIR)/Build/Intermediates.noindex/XCBuildData/*.xcbuild
```

There will only be 1 when you start from a clean state. This file has a `commands` dictionary where a single command has this format:

```yaml
'<random stuff>:Debug:CompileSwiftSources normal x86_64 com.apple.xcode.tools.swift.compiler':
    tool: shell
    description: 'CompileSwiftSources normal x86_64 com.apple.xcode.tools.swift.compiler'
    inputs:
        - /path/to/ViewController.swift
          ...
    outputs:
      ...
    args:
        - /Applications/Xcode.app/Contents/PlugIns/Xcode3Core.ideplugin/Contents/Frameworks/DevToolsCore.framework/Resources/xcexec
        - '-d'
        - /path/to/project
        - '--'
        - /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc
        - '-incremental'
        - '-module-name'
        - testproj
        - '-Onone'
        - '-enforce-exclusivity=checked'
        - '-DDEBUG'
        - '-sdk'
        - /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator11.4.sdk
        - '-target'
        - x86_64-apple-ios11.4
        - '-g'
        - '-module-cache-path'
        - /path/to/deriveddata/ModuleCache.noindex
        - '-Xfrontend'
        - '-serialize-debugging-options'
        - '-enable-testing'
        - '-index-store-path'
        - /path/to/deriveddata/testproj/Index/DataStore
        - '-swift-version'
        - '4'
        - '-I'
        - /path/to/deriveddata/testproj/Build/Products/Debug-iphonesimulator
        - '-F'
        - /path/to/deriveddata/testproj/Build/Products/Debug-iphonesimulator
        - '-c'
        - '-j8'
          ...
    ...
```

We can parse out the input swift files (there can also be non swift files in this array) and the arguments (after the arguments to `xcexec`) to pass to sourcekit.