### PR TITLE
Exit successfully with violations

### DIFF
--- a/Sources/selfish/main.swift
+++ b/Sources/selfish/main.swift
@@ -303,7 +303,6 @@ DispatchQueue.concurrentPerform(iterations: files.count) { index in
                 let (line, char) = contents.lineAndCharacter(forByteOffset: Int(byteOffset))
                 else { fatalError("couldn't convert offsets") }
             print("\(compilableFile.file):\(line):\(char): error: Missing explicit reference to 'self.'")
-            didFindViolations = true
         }
         return
     }
@@ -324,10 +323,4 @@ DispatchQueue.concurrentPerform(iterations: files.count) { index in
     } catch {
         fatalError("can't write file to \(compilableFile.file)")
     }
-
-    if !cursorsMissingExplicitSelf.isEmpty {
-        didFindViolations = true
-    }
 }
-
-exit(didFindViolations ? 1 : 0)


### PR DESCRIPTION
Currently this exiting isn't ideal since if selfish fails for another
reason like an Xcode incompatibility we can't differentiate. Maybe
deleting on how this is used in the future we can enable this just for
lint mode, or with a flag.